### PR TITLE
[fix][security] Fix secure problem CVE-2017-100048

### DIFF
--- a/pulsar-sql/pom.xml
+++ b/pulsar-sql/pom.xml
@@ -43,6 +43,7 @@
         <okhttp3.version>3.14.9</okhttp3.version>
         <!-- use okio version that matches the okhttp3 version -->
         <okio.version>1.17.2</okio.version>
+        <plexus.version>3.0.16</plexus.version>
     </properties>
 
     <dependencyManagement>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -377,7 +377,7 @@ The Apache Software License, Version 2.0
     - plexus-container-default-1.5.5.jar
     - plexus-interpolation-1.14.jar
     - plexus-sec-dispatcher-1.3.jar
-    - plexus-utils-2.0.6.jar
+    - plexus-utils-3.0.16.jar
   * Apache XBean :: Reflect
     - xbean-reflect-3.4.jar
   * Avro

--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -78,6 +78,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+      <version>3.0.16</version>
+    </dependency>
+    <dependency>
       <groupId>io.prestosql</groupId>
       <artifactId>presto-main</artifactId>
       <version>${presto.version}</version>
@@ -98,6 +103,10 @@
         <exclusion>
           <groupId>com.google.inject.extensions</groupId>
           <artifactId>guice-multibindings</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.plexus</groupId>
+          <artifactId>plexus-utils</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -80,7 +80,7 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>3.0.16</version>
+      <version>${plexus.version}</version>
     </dependency>
     <dependency>
       <groupId>io.prestosql</groupId>

--- a/pulsar-sql/presto-pulsar/pom.xml
+++ b/pulsar-sql/presto-pulsar/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
-            <version>3.0.16</version>
+            <version>${plexus.version}</version>
         </dependency>
         <dependency>
             <groupId>io.prestosql</groupId>

--- a/pulsar-sql/presto-pulsar/pom.xml
+++ b/pulsar-sql/presto-pulsar/pom.xml
@@ -114,10 +114,21 @@
         </dependency>
 
         <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+            <version>3.0.16</version>
+        </dependency>
+        <dependency>
             <groupId>io.prestosql</groupId>
             <artifactId>presto-main</artifactId>
             <version>${presto.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.codehaus.plexus</groupId>
+                    <artifactId>plexus-utils</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
### Motivation

The secure problem CVE-2017-1000487 is caused by the dependency `org.codehaus.plexu:plexus-utils:2.0.6`. Refer to [this](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-1000487).

> CVE-2017-1000487
> Plexus-utils before 3.0.16 is vulnerable to command injection because it does not correctly process the contents of double quoted strings.


The dependency tree is this.
```
io.prestosqlpresto-main:332
  -- io.airlift.resolver:resolver:1.5
      -- org.apache.maven:maven-core:3.0.4
           -- org.codehaus.plexus:plexus-utils:2.0.6
```

### Modifications

Exclude the dependency `org.codehaus.plexus:plexus-utils:2.0.6`, and import `org.codehaus.plexus:plexus-utils:3.0.16`.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
